### PR TITLE
Remove ExpressibleByNilLiteral conformance

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -78,12 +78,6 @@ extension Tagged: ExpressibleByIntegerLiteral where RawValue: ExpressibleByInteg
   }
 }
 
-extension Tagged: ExpressibleByNilLiteral where RawValue: ExpressibleByNilLiteral {
-  public init(nilLiteral: ()) {
-    self.init(rawValue: RawValue(nilLiteral: nilLiteral))
-  }
-}
-
 extension Tagged: ExpressibleByStringLiteral where RawValue: ExpressibleByStringLiteral {
   public typealias StringLiteralType = RawValue.StringLiteralType
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.11.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import XCTest
@@ -15,7 +15,6 @@ extension TaggedTests {
     ("testExpressibleByBooleanLiteral", testExpressibleByBooleanLiteral),
     ("testExpressibleByFloatLiteral", testExpressibleByFloatLiteral),
     ("testExpressibleByIntegerLiteral", testExpressibleByIntegerLiteral),
-    ("testExpressibleByNilLiteral", testExpressibleByNilLiteral),
     ("testExpressibleByStringLiteral", testExpressibleByStringLiteral),
     ("testLosslessStringConvertible", testLosslessStringConvertible),
     ("testNumeric", testNumeric),

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -47,10 +47,6 @@ final class TaggedTests: XCTestCase {
     XCTAssertEqual(1, Tagged<Tag, Int>(rawValue: 1))
   }
 
-  func testExpressibleByNilLiteral() {
-    XCTAssertEqual(nil, Tagged<Tag, String?>(rawValue: nil))
-  }
-
   func testExpressibleByStringLiteral() {
     XCTAssertEqual("Hello!", Tagged<Tag, String>(rawValue: "Hello!"))
   }


### PR DESCRIPTION
I think we uncovered that we don't actually want this... right?