### PR TITLE
Add CustomPlaygroundDisplayConvertible conformance to Tagged

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -16,10 +16,8 @@ extension Tagged: CustomStringConvertible {
 extension Tagged: RawRepresentable {
 }
 
-extension Tagged: CustomPlaygroundDisplayConvertible
-{
-  public var playgroundDescription: Any
-  {
+extension Tagged: CustomPlaygroundDisplayConvertible {
+  public var playgroundDescription: Any {
     return self.rawValue
   }
 }

--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -16,6 +16,14 @@ extension Tagged: CustomStringConvertible {
 extension Tagged: RawRepresentable {
 }
 
+extension Tagged: CustomPlaygroundDisplayConvertible
+{
+  public var playgroundDescription: Any
+  {
+    return self.rawValue
+  }
+}
+
 // MARK: - Conditional Conformances
 
 extension Tagged: Comparable where RawValue: Comparable {


### PR DESCRIPTION
Add CustomPlaygroundDisplayConvertible conformance to Tagged

Hi Intent is to open up a pull request to add CustomPlaygroundDisplayConvertible conformance to Tagged. Especially while working with Tagged types like CGRect, the level of indirection through rawValue: made it hard to read in the playground righthand bar and inline views.