### PR TITLE
Fixed Decodable implementation, simplified Encodable implementation

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -36,14 +36,13 @@ extension Tagged: Comparable where RawValue: Comparable {
 
 extension Tagged: Decodable where RawValue: Decodable {
   public init(from decoder: Decoder) throws {
-    self.init(rawValue: try decoder.singleValueContainer().decode(RawValue.self))
+    self.init(rawValue: try .init(from: decoder))
   }
 }
 
 extension Tagged: Encodable where RawValue: Encodable {
   public func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-    try container.encode(self.rawValue)
+    try rawValue.encode(to: encoder)
   }
 }
 

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -74,4 +74,18 @@ final class TaggedTests: XCTestCase {
     let x: Tagged<Tag, Int> = 1
     XCTAssertEqual("1!", x.map { "\($0)!" })
   }
+
+  func testOptionalRawTypeAndNilValueDecodesCorrectly() {
+    struct Container: Decodable {
+      typealias Idenitifer = Tagged<Container, String?>
+      let id: Idenitifer
+    }
+
+    XCTAssertNoThrow(try {
+      let data = "[{\"id\":null}]".data(using: .utf8)!
+      let containers = try JSONDecoder().decode([Container].self, from: data)
+      XCTAssertEqual(containers.count, 1)
+      XCTAssertEqual(containers.first?.id.rawValue, nil)
+      }())
+  }
 }


### PR DESCRIPTION
I'd like to propose fix of Decodable implementation (test included) and adding matching Encodable implementation.

For now test fails with error:
> XCTAssertNoThrow failed: threw error "valueNotFound(Swift.Optional<Swift.String>, Swift.DecodingError.Context(codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "id", intValue: nil)], debugDescription: "Expected Optional<String> but found null value instead.", underlyingError: nil))" 