### PR TITLE
Coerce

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -189,7 +189,7 @@ extension Tagged: SignedNumeric where RawValue: SignedNumeric {
 
 // MARK: - Coerce
 extension Tagged {
-  public func coerced<Tag2>(_ type: Tag2.Type) -> Tagged<Tag2, RawValue> {
+  public func coerced<Tag2>(to type: Tag2.Type) -> Tagged<Tag2, RawValue> {
     return unsafeBitCast(self, to: Tagged<Tag2, RawValue>.self)
   }
 }

--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -189,7 +189,7 @@ extension Tagged: SignedNumeric where RawValue: SignedNumeric {
 
 // MARK: - Coerce
 extension Tagged {
-  public func coerce<Tag2>(_ type: Tag2.Type) -> Tagged<Tag2, RawValue> {
+  public func coerced<Tag2>(_ type: Tag2.Type) -> Tagged<Tag2, RawValue> {
     return unsafeBitCast(self, to: Tagged<Tag2, RawValue>.self)
   }
 }

--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -189,7 +189,7 @@ extension Tagged: SignedNumeric where RawValue: SignedNumeric {
 
 // MARK: - Coerce
 extension Tagged {
-  public func coerce<Tag2>() -> Tagged<Tag2, RawValue> {
+  public func coerce<Tag2>(_ type: Tag2.Type) -> Tagged<Tag2, RawValue> {
     return unsafeBitCast(self, to: Tagged<Tag2, RawValue>.self)
   }
 }

--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -186,3 +186,10 @@ extension Tagged: SignedNumeric where RawValue: SignedNumeric {
 //    self.init(rawValue: f(elements))
 //  }
 //}
+
+// MARK: - Coerce
+extension Tagged {
+  public func coerce<Tag2>() -> Tagged<Tag2, RawValue> {
+    return unsafeBitCast(self, to: Tagged<Tag2, RawValue>.self)
+  }
+}

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -88,13 +88,13 @@ final class TaggedTests: XCTestCase {
       XCTAssertEqual(containers.first?.id.rawValue, nil)
       }())
   }
-	
+
    func testCoerce() {
     let x: Tagged<Tag, Int> = 1
-	
-	enum Tag2 {}
-	let x2: Tagged<Tag2, Int> = x.coerce()
-	
+
+    enum Tag2 {}
+    let x2: Tagged<Tag2, Int> = x.coerce(Tag2.self)
+
     XCTAssertEqual(1, x2.rawValue)
   }
 }

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -93,7 +93,7 @@ final class TaggedTests: XCTestCase {
     let x: Tagged<Tag, Int> = 1
 
     enum Tag2 {}
-    let x2: Tagged<Tag2, Int> = x.coerce(Tag2.self)
+    let x2: Tagged<Tag2, Int> = x.coerced(Tag2.self)
 
     XCTAssertEqual(1, x2.rawValue)
   }

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -88,4 +88,13 @@ final class TaggedTests: XCTestCase {
       XCTAssertEqual(containers.first?.id.rawValue, nil)
       }())
   }
+	
+   func testCoerce() {
+    let x: Tagged<Tag, Int> = 1
+	
+	enum Tag2 {}
+	let x2: Tagged<Tag2, Int> = x.coerce()
+	
+    XCTAssertEqual(1, x2.rawValue)
+  }
 }

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -93,7 +93,7 @@ final class TaggedTests: XCTestCase {
     let x: Tagged<Tag, Int> = 1
 
     enum Tag2 {}
-    let x2: Tagged<Tag2, Int> = x.coerced(Tag2.self)
+    let x2: Tagged<Tag2, Int> = x.coerced(to: Tag2.self)
 
     XCTAssertEqual(1, x2.rawValue)
   }


### PR DESCRIPTION
I implemented an extension to be able to force cast between compatible Tagged data types where the raw representation is the same but the tag changes. This should allow to switch tags when needed instead of creating new wrappers. I hope you'll find it useful. I'm not sure if this is the best solution in terms of usage, though. Here are some equivalent options:

`let x2: Tagged<Tag2, Int> = x.coerce()`

`let x2 = x.coerce(Tagged<Tag2, Int>.self)`

`let x2 = x.coerce(Tag2.self)`

I went with the first one, but I think a case could be made for the rest. I'm not sure if adding all of them would create ambiguity for the compiler.

