### PR TITLE
Add workspace

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -148,8 +148,8 @@ extension Tagged: Numeric where RawValue: Numeric {
 }
 
 extension Tagged: Hashable where RawValue: Hashable {
-  public var hashValue: Int {
-    return self.rawValue.hashValue
+  public func hash(into hasher: inout Hasher) {
+    return hasher.combine(self.rawValue)
   }
 }
 

--- a/Tagged.xcodeproj/project.pbxproj
+++ b/Tagged.xcodeproj/project.pbxproj
@@ -104,7 +104,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FR_1132223CD05B1338B237B6B33E18DD09 /* Tagged.playground */ = {isa = PBXFileReference; path = Tagged.playground; sourceTree = "<group>"; };
 		FR_2D38C1BB2FB99F696CA356426066FBF5 /* Tagged.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tagged.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_587C8A08B167EA6D3972C63CC2E98B74 /* TaggedTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TaggedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_662A9CE5BC4ABA725A52759C0A89BBE9 /* TaggedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TaggedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -195,7 +194,6 @@
 		G_BDA848ED70E8027DFAA00119A86B6FBE = {
 			isa = PBXGroup;
 			children = (
-				FR_1132223CD05B1338B237B6B33E18DD09 /* Tagged.playground */,
 				G_88C1EE64C84665EFE78610B338FAC7A7 /* Sources */,
 				G_F3B104BAAAB6C138CF2EC8710F8D8EEF /* Tests */,
 				G_22A7BB41E6B7EBA1E8C04085706F7E6C /* Products */,

--- a/Tagged.xcworkspace/contents.xcworkspacedata
+++ b/Tagged.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:README.md">
+   </FileRef>
+   <FileRef
+      location = "group:LICENSE">
+   </FileRef>
+   <FileRef
+      location = "group:Tagged.playground">
+   </FileRef>
+   <FileRef
+      location = "group:Tagged.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tagged.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tagged.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,4 @@
 name: Tagged
-fileGroups:
-  - Tagged.playground
 options:
   bundleIdPrefix: co.pointfree
   deploymentTarget:


### PR DESCRIPTION
XcodeGen-generated project files end up changing when you add files like playgrounds, so lets house those in a workspace instead.