### PR TITLE
Error.localizedDescription

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct Tagged<Tag, RawValue> {
   public var rawValue: RawValue
 
@@ -57,6 +59,9 @@ extension Tagged: Equatable where RawValue: Equatable {
 }
 
 extension Tagged: Error where RawValue: Error {
+  public var localizedDescription: String {
+    return rawValue.localizedDescription
+  }
 }
 
 extension Tagged: ExpressibleByBooleanLiteral where RawValue: ExpressibleByBooleanLiteral {

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -70,6 +70,7 @@ final class TaggedTests: XCTestCase {
 
   func testError() {
     XCTAssertThrowsError(try { throw Tagged<Tag, Unit>(rawValue: Unit()) }())
+    XCTAssertEqual(Unit().localizedDescription, Tagged<Tag, Unit>(rawValue: Unit()).localizedDescription)
   }
 
   func testExpressibleByBooleanLiteral() {


### PR DESCRIPTION
Error conformance now properly forwards localizedDescription from rawValue