### PR TITLE
removes error conformance

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -56,9 +56,6 @@ extension Tagged: Equatable where RawValue: Equatable {
   }
 }
 
-extension Tagged: Error where RawValue: Error {
-}
-
 extension Tagged: ExpressibleByBooleanLiteral where RawValue: ExpressibleByBooleanLiteral {
   public typealias BooleanLiteralType = RawValue.BooleanLiteralType
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -11,7 +11,6 @@ extension TaggedTests {
     ("testDecodable", testDecodable),
     ("testEncodable", testEncodable),
     ("testEquatable", testEquatable),
-    ("testError", testError),
     ("testExpressibleByBooleanLiteral", testExpressibleByBooleanLiteral),
     ("testExpressibleByFloatLiteral", testExpressibleByFloatLiteral),
     ("testExpressibleByIntegerLiteral", testExpressibleByIntegerLiteral),

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -68,10 +68,6 @@ final class TaggedTests: XCTestCase {
     XCTAssertEqual(Tagged<Tag, Int>(rawValue: 1), Tagged<Tag, Int>(rawValue: 1))
   }
 
-  func testError() {
-    XCTAssertThrowsError(try { throw Tagged<Tag, Unit>(rawValue: Unit()) }())
-  }
-
   func testExpressibleByBooleanLiteral() {
     XCTAssertEqual(true, Tagged<Tag, Bool>(rawValue: true))
   }


### PR DESCRIPTION
In current state, Tagged Errors dont forward the rawValue's localizedDescription. This is imho very unexpected behavior.

Unfortunatelly, achieving this doesnt seem possible as explained here https://github.com/pointfreeco/swift-tagged/pull/31#issuecomment-513539451

Imho this warrants removing the Error conformance altogether, which this PR does. Up to you guys to decide ;)