### PR TITLE
Localizederror conformance

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -59,6 +59,15 @@ extension Tagged: Equatable where RawValue: Equatable {
 extension Tagged: Error where RawValue: Error {
 }
 
+#if canImport(Foundation)
+import Foundation
+extension Tagged: LocalizedError where RawValue: Error {
+  public var errorDescription: String? {
+    return rawValue.localizedDescription
+  }
+}
+#endif
+
 extension Tagged: ExpressibleByBooleanLiteral where RawValue: ExpressibleByBooleanLiteral {
   public typealias BooleanLiteralType = RawValue.BooleanLiteralType
 

--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -65,6 +65,15 @@ extension Tagged: LocalizedError where RawValue: Error {
   public var errorDescription: String? {
     return rawValue.localizedDescription
   }
+  public var failureReason: String? {
+    return (rawValue as? LocalizedError)?.failureReason
+  }
+  public var helpAnchor: String? {
+    return (rawValue as? LocalizedError)?.helpAnchor
+  }
+  public var recoverySuggestion: String? {
+    return (rawValue as? LocalizedError)?.recoverySuggestion
+  }
 }
 #endif
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -12,6 +12,7 @@ extension TaggedTests {
     ("testEncodable", testEncodable),
     ("testEquatable", testEquatable),
     ("testError", testError),
+    ("testLocalizedError", testLocalizedError),
     ("testExpressibleByBooleanLiteral", testExpressibleByBooleanLiteral),
     ("testExpressibleByFloatLiteral", testExpressibleByFloatLiteral),
     ("testExpressibleByIntegerLiteral", testExpressibleByIntegerLiteral),

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -71,6 +71,13 @@ final class TaggedTests: XCTestCase {
   func testError() {
     XCTAssertThrowsError(try { throw Tagged<Tag, Unit>(rawValue: Unit()) }())
   }
+  
+  #if canImport(Foundation)
+  func testLocalizedError() {
+    let taggedError: Error = Tagged<Tag, Error>(rawValue: Unit())
+    XCTAssertEqual(taggedError.localizedDescription, Unit().localizedDescription)
+  }
+  #endif
 
   func testExpressibleByBooleanLiteral() {
     XCTAssertEqual(true, Tagged<Tag, Bool>(rawValue: true))

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -76,6 +76,19 @@ final class TaggedTests: XCTestCase {
   func testLocalizedError() {
     let taggedError: Error = Tagged<Tag, Error>(rawValue: Unit())
     XCTAssertEqual(taggedError.localizedDescription, Unit().localizedDescription)
+    
+    struct DummyLocalizedError: LocalizedError {
+      var errorDescription: String? { return "errorDescription" }
+      var failureReason: String? { return "failureReason" }
+      var helpAnchor: String? { return "helpAnchor" }
+      var recoverySuggestion: String? { return "recoverySuggestion" }
+    }
+    let taggedLocalizedError: LocalizedError = Tagged<Tag, DummyLocalizedError>(rawValue: DummyLocalizedError())
+    XCTAssertEqual(taggedLocalizedError.localizedDescription, DummyLocalizedError().localizedDescription)
+    XCTAssertEqual(taggedLocalizedError.errorDescription, DummyLocalizedError().errorDescription)
+    XCTAssertEqual(taggedLocalizedError.failureReason, DummyLocalizedError().failureReason)
+    XCTAssertEqual(taggedLocalizedError.helpAnchor, DummyLocalizedError().helpAnchor)
+    XCTAssertEqual(taggedLocalizedError.recoverySuggestion, DummyLocalizedError().recoverySuggestion)
   }
   #endif
 


### PR DESCRIPTION
Adds conformance to LocalizedError for any Tagged that wraps an Error. This is the only way I could find to get localizedDescription working.