### PR TITLE
Swift 5.1 Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ var package = Package(
     .testTarget(name: "TaggedTimeTests", dependencies: ["TaggedTime"]),
   ],
   swiftLanguageVersions: [
-    .v5_1
+    .v5
   ]
 )
 

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,7 @@ var package = Package(
     .testTarget(name: "TaggedTimeTests", dependencies: ["TaggedTime"]),
   ],
   swiftLanguageVersions: [
-    .v4_2,
-    .v5
+    .v5_1
   ]
 )
 

--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -144,6 +144,7 @@ extension Tagged: ExpressibleByUnicodeScalarLiteral where RawValue: ExpressibleB
   }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension Tagged: Identifiable where RawValue: Identifiable {
   public typealias ID = RawValue.ID
 


### PR DESCRIPTION
The `master` branch has eliminated < Swift 5 support. We may wanna look into supporting 4.2 and 5.0 again, but let's wait and see if there's much demand first.