### PR TITLE
Add support for ExpressibleByStringInterpolation

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -136,6 +136,14 @@ extension Tagged: ExpressibleByStringLiteral where RawValue: ExpressibleByString
   }
 }
 
+extension Tagged: ExpressibleByStringInterpolation where RawValue: ExpressibleByStringInterpolation {
+  public typealias StringInterpolation = RawValue.StringInterpolation
+
+  public init(stringInterpolation: Self.StringInterpolation) {
+    self.init(rawValue: RawValue(stringInterpolation: stringInterpolation))
+  }
+}
+
 extension Tagged: ExpressibleByUnicodeScalarLiteral where RawValue: ExpressibleByUnicodeScalarLiteral {
   public typealias UnicodeScalarLiteralType = RawValue.UnicodeScalarLiteralType
 

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -108,6 +108,10 @@ final class TaggedTests: XCTestCase {
     XCTAssertEqual("Hello!", Tagged<Tag, String>(rawValue: "Hello!"))
   }
 
+  func testExpressibleByStringInterpolation() {
+    XCTAssertEqual("Hello \(1 + 1)!", Tagged<Tag, String>(rawValue: "Hello 2!"))
+  }
+
   func testLosslessStringConvertible() {
     // NB: This explicit `.init` shouldn't be necessary, but there seems to be a bug in Swift 5.
     //     Filed here: https://bugs.swift.org/browse/SR-9752


### PR DESCRIPTION
Because:
- It would be nice to express a tag with string interpolation

This commit:
- adds conditional conformance to ExpressibleByStringInterpolation
- adds test