### PR TITLE
Add conditional conformance to PreferenceKey.

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -259,6 +259,22 @@ extension Tagged: Sequence where RawValue: Sequence {
   }
 }
 
+#if canImport(SwiftUI)
+import SwiftUI
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Tagged: PreferenceKey where RawValue: PreferenceKey {
+  public typealias Value = RawValue.Value
+  public static var defaultValue: RawValue.Value {
+    RawValue.defaultValue
+  }
+
+  public static func reduce(value: inout RawValue.Value, nextValue: () -> RawValue.Value) {
+    RawValue.reduce(value: &value, nextValue: nextValue)
+  }
+}
+#endif
+
+
 // Commenting these out for Joe.
 //
 // https://twitter.com/jckarter/status/985375396601282560

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import Tagged
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 
 enum Tag {}
 struct Unit: Error {}
@@ -181,6 +184,19 @@ final class TaggedTests: XCTestCase {
     XCTAssertFalse(x.isEmpty)
     XCTAssertTrue(x.contains(57))
     XCTAssertFalse(x.contains(-57))
+  }
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+  func testPreferenceKey() {
+    struct Key: PreferenceKey {
+      static var defaultValue: Int = 0
+      static func reduce(value: inout Int, nextValue: () -> Int) {
+        value += nextValue()
+      }
+    }
+    var value = Tagged<Tag, Key>.defaultValue
+    Tagged<Tag, Key>.reduce(value: &value, nextValue: { 1 })
+    XCTAssertEqual(value, 1)
   }
 
   func testCoerce() {


### PR DESCRIPTION
It seemed silly to me to create wrapper structs for things like `CGRect` or `[CGRect]`. 

Instead you can just conform those types directly to PreferenceKey, and then use Tagged to create separate classes so you can use them in multiple preferences.

For example:

```swift
extension CGRect: PreferenceKey {
    public typealias Value = CGRect
    public static var defaultValue: CGRect = .zero
    public static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
        value = nextValue()
    }
}

public enum FrameTag {}
public typealias FramePreference = Tagged<FrameTag,CGRect>
```