### PR TITLE
add dynamicMemberLookup to Tagged Type

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -1,3 +1,4 @@
+@dynamicMemberLookup
 public struct Tagged<Tag, RawValue> {
   public var rawValue: RawValue
 
@@ -8,6 +9,12 @@ public struct Tagged<Tag, RawValue> {
   public func map<B>(_ f: (RawValue) -> B) -> Tagged<Tag, B> {
     return .init(rawValue: f(self.rawValue))
   }
+}
+
+extension Tagged {
+    public subscript<T>(dynamicMember keyPath: KeyPath<RawValue, T>) -> T {
+        return self.rawValue[keyPath: keyPath]
+    }
 }
 
 extension Tagged: CustomStringConvertible {

--- a/Tests/TaggedTests/TaggedTests.swift
+++ b/Tests/TaggedTests/TaggedTests.swift
@@ -137,6 +137,17 @@ final class TaggedTests: XCTestCase {
     let x: Tagged<Tag, Int> = 1
     XCTAssertEqual("1!", x.map { "\($0)!" })
   }
+  
+  func testDynamicMemberLookup() {
+    struct MyStruct {
+      let val1: String = "val1"
+      let val2: Int = 1
+    }
+    
+    let x: Tagged<Tag, MyStruct> = Tagged(rawValue: MyStruct())
+    XCTAssertEqual("val1", x.val1)
+    XCTAssertEqual(1, x.val2)
+  }
 
   func testOptionalRawTypeAndNilValueDecodesCorrectly() {
     struct Container: Decodable {


### PR DESCRIPTION
add dynamicMemberLookup and a custom subscript to access the subObject directly.

ex : 

```Swift
    struct MyStruct {
      let val1: String = "val1"
      let val2: Int = 1
    }
    
    let x: Tagged<Tag, MyStruct> = Tagged(rawValue: MyStruct())

    // call x.val1 directly instead of x.rawValue.val1
    x.val1 // --> "val1"
    // call x.val1 directly instead of x.rawValue.val1
    x.val2 // --> 1
```