### PR TITLE
Add UUID helper init

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -101,6 +101,12 @@ extension Tagged: LocalizedError where RawValue: Error {
     return (rawValue as? LocalizedError)?.recoverySuggestion
   }
 }
+
+extension Tagged where RawValue == UUID {
+  public static func uuid(_ uuid: UUID = UUID()) -> Self {
+    return self.init(rawValue: uuid)
+  }
+}
 #endif
 
 extension Tagged: ExpressibleByBooleanLiteral where RawValue: ExpressibleByBooleanLiteral {


### PR DESCRIPTION
Hello!

I'm not sure if this is worth upstreaming. This library works great for creating types for identifiers. However, we cannot take advantage of any [`ExpressibleBy-Literal`](https://github.com/pointfreeco/swift-tagged#expressiblyby-literal) protocols for the `UUID` type so we have to use `User(id: User.Id(rawValue: UUID())`. This addition lets us use `User(id: .uuid())` which is a bit cleaner.

