### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ If you want to use Tagged in a project that uses [SwiftPM](https://swift.org/pac
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-tagged.git", from: "0.5.0")
+  .package(name: "Tagged", url: "https://github.com/pointfreeco/swift-tagged.git", from: "0.5.0")
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ It is important to note that these types do not encapsulate _currency_, but rath
 If you use [Carthage](https://github.com/Carthage/Carthage), you can add the following dependency to your `Cartfile`:
 
 ``` ruby
-github "pointfreeco/swift-tagged" ~> 0.5
+github "pointfreeco/swift-tagged" ~> 0.6
 ```
 
 ### CocoaPods
@@ -384,9 +384,9 @@ github "pointfreeco/swift-tagged" ~> 0.5
 If your project uses [CocoaPods](https://cocoapods.org), just add the following to your `Podfile`:
 
 ``` ruby
-pod 'Tagged', '~> 0.5'
-pod 'TaggedMoney', '~> 0.5'
-pod 'TaggedTime', '~> 0.5'
+pod 'Tagged', '~> 0.6'
+pod 'TaggedMoney', '~> 0.6'
+pod 'TaggedTime', '~> 0.6'
 ```
 
 ### SwiftPM
@@ -395,7 +395,7 @@ If you want to use Tagged in a project that uses [SwiftPM](https://swift.org/pac
 
 ``` swift
 dependencies: [
-  .package(name: "Tagged", url: "https://github.com/pointfreeco/swift-tagged.git", from: "0.5.0")
+  .package(url: "https://github.com/pointfreeco/swift-tagged.git", from: "0.6.0")
 ]
 ```
 


### PR DESCRIPTION
Swift Package Manager requires an explicit package name. It happens since the name deduced from the URL (`swift-tagged`) defers from the name declared in the `Package.swift` file for the version `0.5.0` which is `Tagged`.

If the target dependency is declared as `.product(name: "Tagged", package: "Tagged")` and there is no explicit package name for package dependencies, the following error occurs: "unknown package 'Tagged' in dependencies of target '<target-name>'; valid packages are: 'swift-tagged'".

If the target dependency is declared as `.product(name: "Tagged", package: "swift-tagged")` and there is no explicit package name for package dependencies, the following error occurs: "product dependency 'Tagged' in package 'swift-tagged' not found".