### PR TITLE
Add conditional `Sendable` conformance

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -85,6 +85,10 @@ extension Tagged: Equatable where RawValue: Equatable {}
 
 extension Tagged: Error where RawValue: Error {}
 
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension Tagged: Sendable where RawValue: Sendable {}
+#endif
+
 #if canImport(Foundation)
 import Foundation
 extension Tagged: LocalizedError where RawValue: Error {


### PR DESCRIPTION
This PR allows for `Sendable` conformance when the `RawValue` is also `Sendable`. Attempting to do this *outside* of the package resulted in warnings claiming dual conformance while also complaining if we *don't* add this conformance.