### PR TITLE
Quality-of-life improvements for tagged UUIDs

### DIFF
--- a/Sources/Tagged/UUID.swift
+++ b/Sources/Tagged/UUID.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension Tagged where RawValue == UUID {
+  /// Generates a tagged UUID.
+  ///
+  /// Equivalent to `Tagged<Tag, _>(UUID(())`.
+  public init() {
+    self.init(UUID())
+  }
+
+  /// Creates a tagged UUID from a string representation.
+  ///
+  /// - Parameter string: The string representation of a UUID, such as
+  ///   `DEADBEEF-DEAD-BEED-DEAD-BEEFDEADBEEF`.
+  public init?(uuidString string: String) {
+    guard let uuid = UUID(uuidString: string)
+    else { return nil }
+    self.init(uuid)
+  }
+}


### PR DESCRIPTION
We shortened `User.ID(rawValue: UUID())` to `User.ID(UUID())`, so maybe we allow for the direct construction of them?

Direct construction via `init(uuidString:)` also cleans up tests.