### PR TITLE
Support `ExpressibleByNilLiteral`

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -147,6 +147,12 @@ extension Tagged: ExpressibleByIntegerLiteral where RawValue: ExpressibleByInteg
   }
 }
 
+extension Tagged: ExpressibleByNilLiteral where RawValue: ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) {
+    self.init(rawValue: RawValue(nilLiteral: nilLiteral))
+  }
+}
+
 extension Tagged: ExpressibleByStringLiteral where RawValue: ExpressibleByStringLiteral {
   public typealias StringLiteralType = RawValue.StringLiteralType
 


### PR DESCRIPTION
Just for discussion for now. The use case seems appropriate, but given optional promotion in the language, maybe it's best to avoid potential type-checking issues.