### PR TITLE
Fix episode poster url

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ These concepts (and more) are explored thoroughly in [Point-Free](https://www.po
 Tagged was first explored in [Episode #12](https://www.pointfree.co/episodes/ep12-tagged):
 
 <a href="https://www.pointfree.co/episodes/ep12-tagged">
-  <img alt="video poster image" src="https://d1hf1soyumxcgv.cloudfront.net/0012-tagged/0012-poster.jpg" width="480">
+  <img alt="video poster image" src="https://d3rccdn33rt8ze.cloudfront.net/episodes/0012.jpeg" width="480">
 </a>
 
 ## License


### PR DESCRIPTION
The current episode `src` doesn't display the image.
*Before:*
<img width="505" alt="image" src="https://github.com/pointfreeco/swift-tagged/assets/28612369/c73180d9-bf11-44b6-8294-85d13a72fce3">  
*After:*
<img width="502" alt="image" src="https://github.com/pointfreeco/swift-tagged/assets/28612369/2f10059d-77fe-49ae-a952-2dfc0a72201f">

