### PR TITLE
Add conditional conformance to `BinaryInteger` and `SignedInteger`

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -209,6 +209,83 @@ extension Tagged: Numeric where RawValue: Numeric {
   }
 }
 
+extension Tagged: SignedInteger where RawValue: SignedInteger {}
+
+extension Tagged: BinaryInteger where RawValue: BinaryInteger {
+
+    public static var isSigned: Bool {
+        RawValue.isSigned
+    }
+
+    public init?<T>(exactly source: T) where T : BinaryFloatingPoint {
+        guard let rawValue = RawValue(exactly: source) else { return nil }
+        self.init(rawValue: rawValue)
+    }
+
+    public init<T>(_ source: T) where T : BinaryFloatingPoint {
+        self.init(rawValue: RawValue(source))
+    }
+
+    public init<T>(_ source: T) where T : BinaryInteger {
+        self.init(rawValue: RawValue(source))
+    }
+
+    public init<T>(truncatingIfNeeded source: T) where T : BinaryInteger {
+        self.init(rawValue: RawValue(truncatingIfNeeded: source))
+    }
+
+    public init<T>(clamping source: T) where T : BinaryInteger {
+        self.init(rawValue: RawValue(clamping: source))
+    }
+
+    public var words: RawValue.Words { rawValue.words }
+
+    public var bitWidth: Int { rawValue.bitWidth }
+
+    public var trailingZeroBitCount: Int { rawValue.trailingZeroBitCount }
+
+    public static func / (lhs: Self, rhs: Self) -> Self { Self(rawValue: lhs.rawValue / rhs.rawValue) }
+
+    public static func /= (lhs: inout Self, rhs: Self) { lhs.rawValue /= rhs.rawValue }
+
+    public static func % (lhs: Self, rhs: Self) -> Self { Self(rawValue: lhs.rawValue % rhs.rawValue) }
+
+    public static func %= (lhs: inout Self, rhs: Self) { lhs.rawValue %= rhs.rawValue }
+
+    public prefix static func ~ (x: Self) -> Self { Self(rawValue: ~x.rawValue) }
+
+    public static func & (lhs: Self, rhs: Self) -> Self { Self(rawValue: lhs.rawValue & rhs.rawValue) }
+
+    public static func &= (lhs: inout Self, rhs: Self) { lhs.rawValue &= rhs.rawValue }
+
+    public static func | (lhs: Self, rhs: Self) -> Self { Self(rawValue: lhs.rawValue | rhs.rawValue)}
+
+    public static func |= (lhs: inout Self, rhs: Self) { lhs.rawValue |= rhs.rawValue }
+
+    public static func ^ (lhs: Self, rhs: Self) -> Self { Self(rawValue: lhs.rawValue ^ rhs.rawValue)}
+
+    public static func ^= (lhs: inout Self, rhs: Self) { lhs.rawValue ^= rhs.rawValue }
+
+    public static func >> <RHS>(lhs: Self, rhs: RHS) -> Self where RHS : BinaryInteger { Self(rawValue: lhs.rawValue >> rhs)}
+
+    public static func >>= <RHS>(lhs: inout Self, rhs: RHS) where RHS : BinaryInteger { lhs.rawValue >>= rhs }
+
+    public static func << <RHS>(lhs: Self, rhs: RHS) -> Self where RHS : BinaryInteger { Self(rawValue: lhs.rawValue << rhs)}
+
+    public static func <<= <RHS>(lhs: inout Self, rhs: RHS) where RHS : BinaryInteger{ lhs.rawValue <<= rhs }
+
+    public func quotientAndRemainder(dividingBy rhs: Self) -> (quotient: Self, remainder: Self) {
+        let (q, r) = rawValue.quotientAndRemainder(dividingBy: rhs.rawValue)
+        return (Self(rawValue: q), Self(rawValue: r))
+    }
+
+    public func isMultiple(of other: Self) -> Bool { rawValue.isMultiple(of: other.rawValue) }
+
+    public func signum() -> Self { Self(rawValue: rawValue.signum()) }
+}
+
+
+
 extension Tagged: Hashable where RawValue: Hashable {}
 
 extension Tagged: SignedNumeric where RawValue: SignedNumeric {}

--- a/Tests/TaggedTests/TaggedArithmeticTests.swift
+++ b/Tests/TaggedTests/TaggedArithmeticTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+import Tagged
+
+final class TaggedArithmeticTests: XCTestCase {
+  func test_binaryOperators() {
+    let l = 27
+    let r = 42
+
+    typealias TaggedInt = Tagged<Tag, Int>
+
+    let taggedL = TaggedInt(rawValue: l)
+    let taggedR = TaggedInt(rawValue: r)
+
+    XCTAssertEqual(Int.isSigned, TaggedInt.isSigned)
+
+    XCTAssertEqual(l.trailingZeroBitCount, taggedL.trailingZeroBitCount)
+    XCTAssertEqual(l.bitWidth, taggedL.bitWidth)
+    XCTAssertEqual(l.nonzeroBitCount, taggedL.nonzeroBitCount)
+
+    XCTAssertEqual(l + r, (taggedL + taggedR).rawValue)
+    XCTAssertEqual(l - r, (taggedL - taggedR).rawValue)
+    XCTAssertEqual(l * r, (taggedL * taggedR).rawValue)
+    XCTAssertEqual(l / r, (taggedL / taggedR).rawValue)
+    XCTAssertEqual(l % r, (taggedL % taggedR).rawValue)
+    XCTAssertEqual(~l, ~taggedL.rawValue)
+    XCTAssertEqual(l & r, (taggedL & taggedR).rawValue)
+    XCTAssertEqual(l | r, (taggedL | taggedR).rawValue)
+    XCTAssertEqual(l ^ r, (taggedL ^ taggedR).rawValue)
+    XCTAssertEqual(l >> r, (taggedL >> taggedR).rawValue)
+    XCTAssertEqual(l << r, (taggedL << taggedR).rawValue)
+
+    XCTAssertEqual(l.quotientAndRemainder(dividingBy: r).quotient, taggedL.quotientAndRemainder(dividingBy: taggedR).quotient.rawValue)
+    XCTAssertEqual(l.quotientAndRemainder(dividingBy: r).remainder, taggedL.quotientAndRemainder(dividingBy: taggedR).remainder.rawValue)
+    XCTAssertEqual(l.isMultiple(of: r), taggedL.isMultiple(of: taggedR))
+//    XCTAssertEqual(l.signum(), taggedL.signum())
+
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l += r
+      taggedL += taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l -= r
+      taggedL -= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l *= r
+      taggedL *= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l /= r
+      taggedL /= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l %= r
+      taggedL %= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l &= r
+      taggedL &= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l |= r
+      taggedL |= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l ^= r
+      taggedL ^= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l >>= r
+      taggedL >>= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+    do {
+      var (l, taggedL) = (l, taggedL)
+      l <<= r
+      taggedL <<= taggedR
+      XCTAssertEqual(l, taggedL.rawValue)
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
## What is this?

A year or so back I locally patched `Tagged` to conform to `SignedInteger` and `BinaryInteger`. I thought this seemed useful, so I added it as a change suggestion. @stephencelis responded [it seemed reasonable](https://github.com/pointfreeco/swift-tagged/discussions/81), so here is a PR for it.

## What's done

* Added `Tagged` conformances for `SignedInteger` and `BinaryInteger`. 
* Added tests for the functions in these protocols.
