### PR TITLE
Add SendableMetatype conditional conformance

### DIFF
--- a/Sources/Tagged/Tagged.swift
+++ b/Sources/Tagged/Tagged.swift
@@ -113,6 +113,10 @@ extension Tagged: Sendable where RawValue: Sendable {}
 extension Tagged: BitwiseCopyable where RawValue: BitwiseCopyable {}
 #endif
 
+#if swift(>=6.2)
+extension Tagged: SendableMetatype where RawValue: SendableMetatype {}
+#endif
+
 extension Tagged: ExpressibleByBooleanLiteral where RawValue: ExpressibleByBooleanLiteral {
   public init(booleanLiteral value: RawValue.BooleanLiteralType) {
     self.init(rawValue: RawValue(booleanLiteral: value))


### PR DESCRIPTION
This is a new marker protocol introduced in Swift 6.2.